### PR TITLE
Add store-specific skeuomorphic ticket interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,48 @@
 <html>
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Queue React App</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        background: #f2f2f2;
+        margin: 0;
+        padding: 0;
+      }
+      .container {
+        text-align: center;
+        margin-top: 40px;
+      }
+      #dispenser {
+        width: 200px;
+        height: 300px;
+        background: linear-gradient(#d33, #a00);
+        border-radius: 20px;
+        margin: 40px auto;
+        position: relative;
+        box-shadow: 0 4px 8px rgba(0,0,0,0.4);
+      }
+      #ticket {
+        width: 140px;
+        height: 50px;
+        background: #fff;
+        border: 2px dashed #333;
+        border-radius: 6px;
+        position: absolute;
+        bottom: 20px;
+        left: 50%;
+        transform: translateX(-50%);
+        cursor: grab;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        user-select: none;
+      }
+    </style>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="./app.js"></script>
+    <script type="module" src="/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- create skeuomorphic style for the ticket dispenser
- auto-create store on unknown URL and show dispenser UI
- adjust script path for subdirectory routes

## Testing
- `npm run res:build`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859b949bd7c832d836dad71a5f31799

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a draggable "Pull Ticket" element for queue entry, replacing the previous button-based interaction.
	- Improved mobile responsiveness and visual appearance with updated styles and layout.
- **Refactor**
	- Simplified the user interface by removing store registration fields and focusing on ticket acquisition.
- **Style**
	- Enhanced page aesthetics with a new color scheme, centered layout, and modernized ticket/dispenser visuals.
- **Chores**
	- Updated script loading path for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->